### PR TITLE
Added scripts to handle the edgerouters that use multiple WAN interfaces with Load Balancing

### DIFF
--- a/dualWan/README.md
+++ b/dualWan/README.md
@@ -1,2 +1,13 @@
 # WireGuard-on-Edgerouter-x with Dual WAN 
 
+When using the Dual Wan (or multiple WAN) configuration with the edgerouter, the standard scripts needed to modified to handle the case where the modify balance group already exists, as well as existing nat masquarade rules.
+
+This script will route all traffic for addressGroup "wgClients" over wg0. any addresses not in wgClients will be routed normally. You should define wgClients beforehand, either via command line or the gui.
+
+assuming you have a working wg0.conf style config (saved as wg0.conf in this example) file from your provider and that wgClients address group is defined, you can turn on the VPN using the following:
+
+```./startVPN.sh wg0.conf```
+
+and stop with the following:
+
+```./stopVPN.sh wg0.conf```

--- a/dualWan/README.md
+++ b/dualWan/README.md
@@ -1,0 +1,2 @@
+# WireGuard-on-Edgerouter-x with Dual WAN 
+

--- a/dualWan/startVPN.sh
+++ b/dualWan/startVPN.sh
@@ -1,0 +1,56 @@
+#!/bin/vbash
+
+#you must supply a wg0.conf config file on the command line to this script
+if [ -z ${1+x} ] ; then 
+	echo "configure file is unset"
+	echo "$0 wg.conf [-test]"
+	exit 1
+fi
+	
+name=wg0 #the wireguard device name
+add=`grep Address $1 |sed -e 's/,/ /g' |awk '{print $3}'`  #the assigned IP address from your provider
+pub=`grep Pub $1 |awk '{print $3}'` #Providers Public Key
+pri=`grep Pri $1 |awk '{print $3}'` #Your private Key
+end=`grep Endp $1 |awk '{print $3}'` #providers IP and port
+out=`echo $add |sed -e 's/\// /g' |awk '{print $1}'` 
+firewallModify=balance #the modify firewall rule set used by load balancer
+networkGroup=wgClients   # the network group of devices to route over wireguard
+
+if [ "$2" = "-test" ] ; then
+	cfg="echo TEST: /opt/vyatta/sbin/vyatta-cfg-cmd-wrapper"
+else
+	cfg="/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper"
+fi
+
+$cfg begin
+$cfg set interfaces wireguard $name address $add
+$cfg set interfaces wireguard $name listen-port 51820
+$cfg set interfaces wireguard $name route-allowed-ips false
+$cfg set interfaces wireguard $name peer $pub endpoint $end
+$cfg set interfaces wireguard $name peer $pub allowed-ips 0.0.0.0/0
+$cfg set interfaces wireguard $name private-key $pri
+
+$cfg commit
+$cfg set service nat rule 5004 description 'wireguard'
+$cfg set service nat rule 5004 log disable
+$cfg set service nat rule 5004 outbound-interface $name
+$cfg set service nat rule 5004 outside-address address $out
+##$cfg set service nat rule 5004 source address $source
+$cfg set service nat rule 5004 source group address-group $networkGroup
+$cfg set service nat rule 5004 type source
+$cfg commit
+
+$cfg set protocols static table 41 interface-route 0.0.0.0/0 next-hop-interface $name
+$cfg set firewall modify $firewallModify rule 41 description 'to WG'
+#$cfg set firewall modify $firewallModify rule 41 source address $source
+$cfg set firewall modify $firewallModify rule 41 source group address-group wgClients
+$cfg set firewall modify $firewallModify rule 41 modify table 41
+
+#this should already be set if you have load balancing enabled
+#$cfg set interfaces switch switch0 firewall in modify $firewallModify
+#$cfg set service dns forwarding name-server 8.8.8.8
+
+$cfg commit  #enable the changes to the running config
+#$cfg save  #save the config to last across reboots 
+$cfg end
+

--- a/dualWan/stopVPN.sh
+++ b/dualWan/stopVPN.sh
@@ -1,0 +1,35 @@
+#!/bin/vbash
+
+#you must supply a wg0.conf config file on the command line to this script
+if [ -z ${1+x} ] ; then 
+	echo "configure file is unset"
+	echo "$0 wg.conf [-test]"
+	exit 1
+fi
+	
+name=wg0 #the wireguard device name
+add=`grep Address $1 |sed -e 's/,/ /g' |awk '{print $3}'`  #the assigned IP address from your provider
+pub=`grep Pub $1 |awk '{print $3}'` #Providers Public Key
+pri=`grep Pri $1 |awk '{print $3}'` #Your private Key
+end=`grep Endp $1 |awk '{print $3}'` #providers IP and port
+out=`echo $add |sed -e 's/\// /g' |awk '{print $1}'` 
+firewallModify=balance #the modify firewall rule set used by load balancer
+networkGroup=wgClients   # the network group of devices to route over wireguard
+
+if [ "$2" = "-test" ] ; then
+	cfg="echo TEST: /opt/vyatta/sbin/vyatta-cfg-cmd-wrapper"
+else
+	cfg="/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper"
+fi
+
+$cfg begin
+
+$cfg delete interfaces wireguard 
+$cfg delete service nat rule 5004 
+$cfg delete protocols static table 41 
+$cfg delete firewall modify $firewallModify rule 41
+
+$cfg commit  #commit the current changes to the running config
+#$cfg save #save the changes to the config.boot to last across reboots
+$cfg end
+


### PR DESCRIPTION
These scripts accommodate the creation of a wireguard tunnel in an edgerouter environment that uses load balancing and multiple WAN interfaces. 

The scripts are in a "dualWan" directory and no changes to the existing scripts were made.